### PR TITLE
Set status & activity in the bot constructor

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,3 @@
 <!--
-* Test your code before submitting a PR, check https://github.com/nh-server/Kurisu on how to do so
+* Test your code before submitting a PR, check the README for this project on how to do so
 -->

--- a/twlhelper.py
+++ b/twlhelper.py
@@ -38,7 +38,6 @@ class TWLHelper(commands.Bot):
 
     async def on_ready(self):
         print("TWLHelper ready.")
-        await self.change_presence(status=discord.Status.online, activity=discord.Game(settings.STATUS))
 
     async def on_command_error(self, ctx: commands.Context, exc: commands.CommandInvokeError):
         author: discord.Member = ctx.author
@@ -91,7 +90,9 @@ class TWLHelper(commands.Bot):
 def main():
     intents = discord.Intents(guilds=True, members=True, bans=True, messages=True)
 
-    bot = TWLHelper(settings.PREFIX, description="TWLHelper, DS⁽ⁱ⁾ Mode Hacking Discord server bot", allowed_mentions=discord.AllowedMentions(everyone=False, roles=False), intents=intents, case_insensitive=True)
+    bot = TWLHelper(settings.PREFIX, description="TWLHelper, DS⁽ⁱ⁾ Mode Hacking Discord server bot",
+                    allowed_mentions=discord.AllowedMentions(everyone=False, roles=False), intents=intents,
+                    case_insensitive=True, status=discord.Status.online, activity=discord.Game(settings.STATUS))
     bot.help_command = embedHelp()
     print('Starting TWLHelper...')
     bot.load_cogs()


### PR DESCRIPTION
## Summary

- Sets status and activity in the bot constructor instead of doing it on_ready.

Doing this in on_ready is bad practice and doesn't guarantee the status will stay the same after a reconnect

- Updates the PR template to remove references to NH
