### PR TITLE
Add a Literal converter

### DIFF
--- a/cogs/general.py
+++ b/cogs/general.py
@@ -1,11 +1,9 @@
-from typing import Literal
-
 import discord
 
 from discord.ext import commands
 from inspect import cleandoc
 
-from utils.utils import check_arg
+from utils import check_arg, Literal
 
 
 class General(commands.Cog):
@@ -15,7 +13,6 @@ class General(commands.Cog):
 
     def __init__(self, bot):
         self.bot = bot
-        self.systems = ("3ds", "wiiu", "vwii", "switch", "nx", "ns", "wii", "dsi")
 
     async def simple_embed(self, ctx, text, *, title="", color=discord.Color.default()):
         embed = discord.Embed(title=title, color=color)
@@ -23,14 +20,8 @@ class General(commands.Cog):
         await ctx.send(embed=embed)
 
     @commands.command()
-    async def guide(self, ctx, *guides) -> None:
+    async def guide(self, ctx, *guides: Literal("3ds", "wiiu", "vwii", "switch", "nx", "ns", "wii", "dsi")) -> None:  # noqa
         """Links to the recommended guides"""
-        guides = {x.lower() for x in guides if x.lower() in self.systems}
-
-        if not guides:
-            await ctx.send(f"Please specify a console. Valid options are: {', '.join([x for x in self.systems])}.")
-            return
-
         embed = discord.Embed(title="Guide")
         for x in guides:
             if check_arg(x, '3ds'):
@@ -126,7 +117,7 @@ class General(commands.Cog):
         await ctx.send(embed=embed)
 
     @commands.command()
-    async def dump(self, ctx, system: Literal['3ds', 'dsi', 'dsiware']):
+    async def dump(self, ctx, system: Literal('3ds', 'dsi', 'dsiware')):  # noqa
         """How to dump games and data for CFW consoles"""
         if check_arg(system, '3ds'):
             embed = discord.Embed(title="GodMode9 Dump Guide")

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,2 @@
+from .converters import *  # noqa
+from .utils import *  # noqa

--- a/utils/converters.py
+++ b/utils/converters.py
@@ -1,0 +1,19 @@
+from discord.ext import commands
+
+__all__ = ("Literal",)
+
+
+class Literal:
+    """Similar to typing.Literal except this is designed for lowercased literals.
+
+    This also calls str.lower() on the argument during conversion.
+    """
+    def __init__(self, *literals):
+        self.literals = [x.lower() for x in literals]
+
+    async def convert(self, ctx: commands.Context, argument: str) -> str:
+        largument = argument.lower()
+        if largument in self.literals:
+            return largument
+        else:
+            raise commands.UserInputError(f"Expected one of {' '.join(self.literals)}.")

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -19,6 +19,13 @@ import discord
 import settings
 from discord.ext import commands
 
+__all__ = ("send_dm_message",
+           "command_signature",
+           "create_error_embed",
+           "is_staff",
+           "check_arg",
+           "web_name")
+
 
 async def send_dm_message(member: discord.Member, message: str, ctx: commands.Context = None, **kwargs) -> bool:
     """A helper function for sending a message to a member's DMs.


### PR DESCRIPTION
## Summary
- Adds a Literal converter designed for lowercased literals
- Use new Literal converter for `dump` & `guide`.
- Made it easier to import utils

I haven't tested this, but it should work fine.