### PR TITLE
Auto-translated international channel support

### DIFF
--- a/cogs/international.py
+++ b/cogs/international.py
@@ -66,7 +66,7 @@ class International(commands.Cog):
                         if edit:
                             await self.messagecache[message.id].edit(translation["text"])
                         else:
-                            embed = None
+                            embeds = message.embeds
                             if message.reference:
                                 if message.reference.message_id in self.messagecache:
                                     reply = self.messagecache[message.reference.message_id]
@@ -77,13 +77,14 @@ class International(commands.Cog):
                                         reply = await ch.fetch_message(id)
                                     else:
                                         reply = await message.channel.fetch_message(message.reference.message_id)
-                                embed = discord.Embed(description=reply.content)
+                                if len(reply.content) > 0:
+                                    embeds.append(discord.Embed(description=reply.content))
 
                             webhookmsg = await self.webhooks[i11l_channel["EN"]["ID"]].send(
                                 content=translation["text"],
                                 username=f"{message.author.display_name} [{translation['detected_source_language']}]",
                                 avatar_url=message.author.display_avatar,
-                                embed=embed,
+                                embeds=embeds,
                                 wait=True
                             )
 
@@ -113,7 +114,7 @@ class International(commands.Cog):
                     if edit:
                         await self.messagecache[message.id].edit(msg)
                     else:
-                        embed = None
+                        embeds = message.embeds
                         if message.reference:
                             if message.reference.message_id in self.messagecache:
                                 reply = self.messagecache[message.reference.message_id]
@@ -124,13 +125,14 @@ class International(commands.Cog):
                                     reply = await ch.fetch_message(id)
                                 else:
                                     reply = await message.channel.fetch_message(message.reference.message_id)
-                            embed = discord.Embed(description=reply.content)
+                            if len(reply.content) > 0:
+                                embeds.append(discord.Embed(description=reply.content))
 
                         webhookmsg = await self.webhooks[i11l_channel["I11L"]["ID"]].send(
                             content=msg,
                             username=message.author.display_name,
                             avatar_url=message.author.display_avatar,
-                            embed=embed,
+                            embeds=embeds,
                             wait=True
                         )
                         self.messagecache[message.id] = webhookmsg

--- a/cogs/international.py
+++ b/cogs/international.py
@@ -1,0 +1,55 @@
+#
+# ISC License
+#
+# Copyright (C) 2021-present DS-Homebrew
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+
+import discord
+import settings
+
+
+from discord.ext import commands
+from urllib.parse import quote
+
+
+class International(commands.Cog):
+    """International channel handling"""
+
+    def __init__(self, bot):
+        self.bot = bot
+
+    @commands.Cog.listener()
+    async def on_message(self, message: discord.Message):
+        if message.guild.id == settings.GUILD:
+            for i11l_channel in settings.I11L:
+                if i11l_channel["ID"] == message.channel.id:
+                    webhook = discord.Webhook.partial(
+                        i11l_channel["WEBHOOK_ID"],
+                        i11l_channel["WEBHOOK_TOKEN"],
+                        session=self.bot.session
+                    )
+
+                    # Translate with DeepL
+                    async with self.bot.session.get(f"https://api-free.deepl.com/v2/translate?auth_key={settings.DEEPLTOKEN}&target_lang=EN-US&text={quote(message.content)}") as response:
+                        await webhook.send(
+                            content=(await response.json())["translations"][0]["text"],
+                            username=message.author.display_name,
+                            avatar_url=message.author.avatar
+                        )
+
+
+async def setup(bot):
+    await bot.add_cog(International(bot))

--- a/cogs/international.py
+++ b/cogs/international.py
@@ -80,6 +80,14 @@ class International(commands.Cog):
                                 if len(reply.content) > 0:
                                     embeds.append(discord.Embed(description=reply.content))
 
+                            for attachment in message.attachments:
+                                if attachment.content_type.startswith("image"):
+                                    embed = discord.Embed()
+                                    embed.set_image(url=attachment.url)
+                                    embeds.append(embed)
+                                else:
+                                    embeds.append(discord.Embed(description=f"[{attachment.description}]({attachment.url})"))
+
                             webhookmsg = await self.webhooks[i11l_channel["EN"]["ID"]].send(
                                 content=translation["text"],
                                 username=f"{message.author.display_name} [{translation['detected_source_language']}]",
@@ -127,6 +135,14 @@ class International(commands.Cog):
                                     reply = await message.channel.fetch_message(message.reference.message_id)
                             if len(reply.content) > 0:
                                 embeds.append(discord.Embed(description=reply.content))
+
+                        for attachment in message.attachments:
+                            if attachment.content_type.startswith("image"):
+                                embed = discord.Embed()
+                                embed.set_image(url=attachment.url)
+                                embeds.append(embed)
+                            else:
+                                embeds.append(discord.Embed(description=f"[{attachment.filename}]({attachment.url})"))
 
                         webhookmsg = await self.webhooks[i11l_channel["I11L"]["ID"]].send(
                             content=msg,

--- a/cogs/international.py
+++ b/cogs/international.py
@@ -64,7 +64,10 @@ class International(commands.Cog):
                     async with self.bot.session.get(f"https://api-free.deepl.com/v2/translate?auth_key={settings.DEEPLTOKEN}&target_lang=EN-US&text={quote(message.content)}") as response:
                         translation = (await response.json())["translations"][0]
                         if edit:
-                            await self.messagecache[message.id].edit(translation["text"])
+                            await self.messagecache[message.id].edit(
+                                content=translation["text"],
+                                embeds=message.embeds + self.messagecache[message.id].embeds[len(message.embeds):]
+                            )
                         else:
                             embeds = message.embeds
                             if message.reference:
@@ -120,7 +123,10 @@ class International(commands.Cog):
                             msg = (await response.json())["translations"][0]["text"]
 
                     if edit:
-                        await self.messagecache[message.id].edit(msg)
+                        await self.messagecache[message.id].edit(
+                            content=msg,
+                            embeds=message.embeds + self.messagecache[message.id].embeds[len(message.embeds):]
+                        )
                     else:
                         embeds = message.embeds
                         if message.reference:

--- a/cogs/international.py
+++ b/cogs/international.py
@@ -60,7 +60,7 @@ class International(commands.Cog):
 
                     # Check for language code in name from autotranslated message
                     language_code = "EN"
-                    if message.reference.message_id:
+                    if message.reference:
                         reply = await message.channel.fetch_message(message.reference.message_id)
                         matches = findall(r"\[([A-Z\-]{2,5})\]", reply.author.display_name)
                         if len(matches) > 0:

--- a/settings.json.example
+++ b/settings.json.example
@@ -27,9 +27,16 @@
 
     "I11L": [
         {
-            "ID": null,
-            "WEBHOOK_ID": null,
-            "WEBHOOK_TOKEN": ""
+            "I11L": {
+                "ID": null,
+                "WEBHOOK_ID": null,
+                "WEBHOOK_TOKEN": ""
+            },
+            "EN": {
+                "ID": null,
+                "WEBHOOK_ID": null,
+                "WEBHOOK_TOKEN": ""
+            }
         }
     ],
     

--- a/settings.json.example
+++ b/settings.json.example
@@ -25,5 +25,15 @@
         "MISCUPDATES": null
     },
 
-    "GSPREADKEY": null
+    "I11L": [
+        {
+            "ID": null,
+            "WEBHOOK_ID": null,
+            "WEBHOOK_TOKEN": ""
+        }
+    ],
+    
+
+    "GSPREADKEY": null,
+    "DEEPLTOKEN": null
 }

--- a/settings.py
+++ b/settings.py
@@ -45,3 +45,7 @@ TWLUPDATES = settings['THREAD']['TWLUPDATES']
 NDSBUPDATES = settings['THREAD']['NDSBUPDATES']
 WEBUPDATES = settings['THREAD']['WEBUPDATES']
 MISCUPDATES = settings['THREAD']['MISCUPDATES']
+
+# international channels
+I11L = settings['I11L']
+DEEPLTOKEN = settings.get('DEEPLTOKEN')

--- a/twlhelper.py
+++ b/twlhelper.py
@@ -143,8 +143,8 @@ async def main():
     bot = TWLHelper(settings.PREFIX, description="TWLHelper, DS⁽ⁱ⁾ Mode Hacking Discord server bot")
     print('Starting TWLHelper...')
     async with bot:
-        await bot.load_cogs()
         bot.session = aiohttp.ClientSession()
+        await bot.load_cogs()
         await bot.start(settings.TOKEN)
 
 


### PR DESCRIPTION
This adds handling for "international" channels which function as a pair of one channel where non-English languages are allowed and one channel where only English is used, primarily for ease of moderation.

Any message sent to the international channel will be automatically translated to English, if needed messages can also be sent in the English channel as either replies to an autotranslated message or starting with "language code:" (ex. "ja: hello") to be translated back to that language in the international channel.