### PR TITLE
nicompare: add description to parameters

### DIFF
--- a/cogs/nointro.py
+++ b/cogs/nointro.py
@@ -47,7 +47,7 @@ class NoIntro(commands.Cog):
         return True
 
     @commands.command(usage="<title id|game name> <sha1 hash>")
-    async def nicompare(self, ctx, gamecode: str, sha1hash: str):
+    async def nicompare(self, ctx, gamecode: str = commands.parameter(description="4 letter game code (e.g. YLZX)"), sha1hash: str = commands.parameter(description="SHA1 hash of the ROM file")):
         """
         Compares input ROM and hash against No-Intro.
         At the moment, only SHA1 comparison is supported.


### PR DESCRIPTION
There was confusion around how this command should be used. I've added a description to both of the parameters so that people know what to input.

Here is how it will look when run without any arguments/with help command:

![image](https://github.com/user-attachments/assets/c083e9f2-5b5d-4a17-a441-fee6bde3d752)


<!--
* Test your code before submitting a PR, check the README for this project on how to do so
-->
